### PR TITLE
compute gradients with torchscript

### DIFF
--- a/comp550/model/_differentiable_embedding.py
+++ b/comp550/model/_differentiable_embedding.py
@@ -1,13 +1,18 @@
 
 import torch
 import torch.nn as nn
+import torch.functional as F
 
-class DifferentiableEmbedding(nn.Embedding):
+class DifferentiableEmbedding(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.embedding = nn.Embedding(*args, **kwargs)
+
     def forward(self, x):
         # To support gradient w.r.t. input, we must allow x to be a float-tensor.
         if torch.is_floating_point(x):
-            h = torch.matmul(x, self.weight)
+            h = torch.matmul(x, self.embedding.weight)
         else:
-            h = super().forward(x)
+            h = self.embedding(x)
 
         return h

--- a/comp550/model/single_sequence_to_class.py
+++ b/comp550/model/single_sequence_to_class.py
@@ -22,7 +22,7 @@ class _Encoder(nn.Module):
         h1 = self.embedding(x)
         h1_packed = nn.utils.rnn.pack_padded_sequence(h1, length, batch_first=True, enforce_sorted=False)
         h2_packed, _ = self.rnn(h1_packed)
-        h2_unpacked, _ = nn.utils.rnn.pad_packed_sequence(h2_packed, batch_first=True, padding_value=0)
+        h2_unpacked, _ = nn.utils.rnn.pad_packed_sequence(h2_packed, batch_first=True, padding_value=0.0)
         return h2_unpacked
 
 class _Attention(nn.Module):


### PR DESCRIPTION
**work in progress** Just wanted to stash this code I was working on, because the gradient calculations are crazy slow, but should theoretically not take much more than 1 epoch.

TensorFlow and JAX have much better ways of doing batch_gradients w.r.t. to input, however that is not supported in PyTorch. I was hopeing compiling the module with TorchScript was going to improve performance and memory. Perhaps also allow us to inline a batch_loop in the gradient calcuations, instead of computing them one-by-one.

Current issue is that dynamic dict inputs like `batch` is not supported. Apparently there are ways to inform PyTorch that the dict doesn't change shape (is static), but I need to read more about it.