### PR TITLE
move roar results to their own sub-directory

### DIFF
--- a/batch_jobs/babi.sh
+++ b/batch_jobs/babi.sh
@@ -6,7 +6,7 @@ for seed in {0..4}
 do
     for type in 1 2 3
     do
-        if [ ! -f $SCRATCH"/comp550/results/babi-${type}_s-${seed}.json" ]; then
+        if [ ! -f $SCRATCH"/comp550/results/roar/babi-${type}_s-${seed}.json" ]; then
             echo babi-${type}_s-${seed}
             sbatch --time=${time[$type]} --mem=6G \
                 -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/babi_roar.sh
+++ b/batch_jobs/babi_roar.sh
@@ -13,7 +13,7 @@ do
         do
             for k in {1..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
                     echo babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0
                     sbatch --time=${time[$type $importance_measure]} --mem=6G \
                         -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
@@ -27,7 +27,7 @@ do
 
             for k in {10..90..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
                     echo babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0
                     sbatch --time=${time[$type $importance_measure]} --mem=6G \
                         -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/babi_roar_recursive.sh
+++ b/batch_jobs/babi_roar_recursive.sh
@@ -18,7 +18,7 @@ do
 
             for k in {1..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
                     echo babi-${type}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1
                     if last_jobid=$(
                         sbatch --time=${time[$type $importance_measure]} --mem=6G --parsable ${dependency} \
@@ -42,7 +42,7 @@ do
 
             for k in {10..90..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
                     echo babi-${type}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1
                     if last_jobid=$(
                         sbatch --time=${time[$type $importance_measure]} --mem=6G --parsable ${dependency} \

--- a/batch_jobs/imdb.sh
+++ b/batch_jobs/imdb.sh
@@ -2,7 +2,7 @@
 # Actual time: "0:04:0"
 for seed in {0..4}
 do
-    if [ ! -f $SCRATCH"/comp550/results/imdb_s-${seed}.json" ]; then
+    if [ ! -f $SCRATCH"/comp550/results/roar/imdb_s-${seed}.json" ]; then
         echo imdb_s-${seed}
         sbatch --time=0:15:0 --mem=6G \
             -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/imdb_roar.sh
+++ b/batch_jobs/imdb_roar.sh
@@ -9,7 +9,7 @@ do
     do
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
                 echo imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=6G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
@@ -22,7 +22,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
                 echo imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=6G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/imdb_roar_recursive.sh
+++ b/batch_jobs/imdb_roar_recursive.sh
@@ -12,7 +12,7 @@ do
 
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
                 echo imdb_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                         sbatch --time=${time[$importance_measure]} --mem=6G --parsable ${dependency} \
@@ -35,7 +35,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
                 echo imdb_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                         sbatch --time=${time[$importance_measure]} --mem=6G --parsable ${dependency} \

--- a/batch_jobs/mimic.sh
+++ b/batch_jobs/mimic.sh
@@ -7,7 +7,7 @@ for seed in {0..4}
 do
     for subset in 'anemia' 'diabetes'
     do
-        if [ ! -f $SCRATCH"/comp550/results/mimic-${subset::1}_s-${seed}.json" ]; then
+        if [ ! -f $SCRATCH"/comp550/results/roar/mimic-${subset::1}_s-${seed}.json" ]; then
             echo mimic-${subset::1}_s-${seed}
             sbatch --time=${time[$subset]} --mem=8G \
                 -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/mimic_roar.sh
+++ b/batch_jobs/mimic_roar.sh
@@ -12,7 +12,7 @@ do
         do
             for k in {1..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
                     echo mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0
                     sbatch --time=${time[$subset $importance_measure]} --mem=8G \
                         -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
@@ -26,7 +26,7 @@ do
 
             for k in {10..90..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
                     echo mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0
                     sbatch --time=${time[$subset $importance_measure]} --mem=8G \
                         -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/mimic_roar_recursive.sh
+++ b/batch_jobs/mimic_roar_recursive.sh
@@ -16,7 +16,7 @@ do
 
             for k in {1..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
                     echo mimic-${subset::1}_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1
                     if last_jobid=$(
                         sbatch --time=${time[$subset $importance_measure]} --mem=8G --parsable ${dependency} \
@@ -40,7 +40,7 @@ do
 
             for k in {10..90..10}
             do
-                if [ ! -f $SCRATCH"/comp550/results/mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
+                if [ ! -f $SCRATCH"/comp550/results/roar/mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
                     echo mimic-${subset::1}_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1
                     if last_jobid=$(
                         sbatch --time=${time[$subset $importance_measure]} --mem=8G --parsable ${dependency} \

--- a/batch_jobs/stanford_nli.sh
+++ b/batch_jobs/stanford_nli.sh
@@ -2,7 +2,7 @@
 # Actual time: ["anemia"]="0:44:0"
 for seed in {0..4}
 do
-    if [ ! -f $SCRATCH"/comp550/results/snli_s-${seed}.json" ]; then
+    if [ ! -f $SCRATCH"/comp550/results/roar/snli_s-${seed}.json" ]; then
         echo snli_s-${seed}
         sbatch --time=1:10:0 --mem=24G -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
             -J snli_s-${seed} ./python_job.sh \

--- a/batch_jobs/stanford_nli_roar.sh
+++ b/batch_jobs/stanford_nli_roar.sh
@@ -9,7 +9,7 @@ do
     do
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
                 echo snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=24G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
@@ -22,7 +22,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
                 echo snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=24G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/stanford_nli_roar_recursive.sh
+++ b/batch_jobs/stanford_nli_roar_recursive.sh
@@ -12,7 +12,7 @@ do
 
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
                 echo snli_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                     sbatch --time=${time[$importance_measure]} --mem=24G --parsable ${dependency} \
@@ -35,7 +35,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
                 echo snli_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                     sbatch --time=${time[$importance_measure]} --mem=24G --parsable ${dependency} \

--- a/batch_jobs/stanford_sentiment.sh
+++ b/batch_jobs/stanford_sentiment.sh
@@ -3,7 +3,7 @@
 
 for seed in {0..4}
 do
-    if [ ! -f $SCRATCH"/comp550/results/sst_s-${seed}.json" ]; then
+    if [ ! -f $SCRATCH"/comp550/results/roar/sst_s-${seed}.json" ]; then
         echo sst_s-${seed}
         sbatch --time=0:10:0 --mem=6G \
             -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/stanford_sentiment_roar.sh
+++ b/batch_jobs/stanford_sentiment_roar.sh
@@ -9,7 +9,7 @@ do
     do
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0.json" ]; then
                 echo sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=6G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \
@@ -22,7 +22,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0.json" ]; then
                 echo sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-0
                 sbatch --time=${time[$importance_measure]} --mem=6G \
                     -o $SCRATCH"/comp550/logs/%x.%j.out" -e $SCRATCH"/comp550/logs/%x.%j.err" \

--- a/batch_jobs/stanford_sentiment_roar_recursive.sh
+++ b/batch_jobs/stanford_sentiment_roar_recursive.sh
@@ -12,7 +12,7 @@ do
 
         for k in {1..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1.json" ]; then
                 echo sst_s-${seed}_k-${k}_y-c_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                     sbatch --time=${time[$importance_measure]} --mem=6G --parsable ${dependency} \
@@ -35,7 +35,7 @@ do
 
         for k in {10..90..10}
         do
-            if [ ! -f $SCRATCH"/comp550/results/sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
+            if [ ! -f $SCRATCH"/comp550/results/roar/sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1.json" ]; then
                 echo sst_s-${seed}_k-${k}_y-q_m-${importance_measure::1}_r-1
                 if last_jobid=$(
                     sbatch --time=${time[$importance_measure]} --mem=6G --parsable ${dependency} \

--- a/experiments/babi.py
+++ b/experiments/babi.py
@@ -170,8 +170,8 @@ if __name__ == "__main__":
     )[0]
     print(results)
 
-    os.makedirs(f'{args.persistent_dir}/results', exist_ok=True)
-    with open(f'{args.persistent_dir}/results/{experiment_id}.json', "w") as f:
+    os.makedirs(f'{args.persistent_dir}/results/roar', exist_ok=True)
+    with open(f'{args.persistent_dir}/results/roar/{experiment_id}.json', "w") as f:
         json.dump({"seed": args.seed, "dataset": f"babi-{args.task}", "strategy": args.roar_strategy,
                    "k": args.k, "recursive": args.recursive, "importance_measure": args.importance_measure,
                    **results}, f)

--- a/experiments/imdb.py
+++ b/experiments/imdb.py
@@ -164,8 +164,8 @@ if __name__ == '__main__':
     )[0]
     print(results)
 
-    os.makedirs(f'{args.persistent_dir}/results', exist_ok=True)
-    with open(f'{args.persistent_dir}/results/{experiment_id}.json', "w") as f:
+    os.makedirs(f'{args.persistent_dir}/results/roar', exist_ok=True)
+    with open(f'{args.persistent_dir}/results/roar/{experiment_id}.json', "w") as f:
         json.dump({"seed": args.seed, "dataset": f"imdb", "strategy": args.roar_strategy,
                    "k": args.k, "recursive": args.recursive, "importance_measure": args.importance_measure,
                    **results}, f)

--- a/experiments/mimic.py
+++ b/experiments/mimic.py
@@ -166,8 +166,8 @@ if __name__ == "__main__":
     )[0]
     print(results)
 
-    os.makedirs(f'{args.persistent_dir}/results', exist_ok=True)
-    with open(f'{args.persistent_dir}/results/{experiment_id}.json', "w") as f:
+    os.makedirs(f'{args.persistent_dir}/results/roar', exist_ok=True)
+    with open(f'{args.persistent_dir}/results/roar/{experiment_id}.json', "w") as f:
         json.dump({"seed": args.seed, "dataset": f"mimic-{args.subset}", "strategy": args.roar_strategy,
                    "k": args.k, "recursive": args.recursive, "importance_measure": args.importance_measure,
                    **results}, f)

--- a/experiments/stanford_nli.py
+++ b/experiments/stanford_nli.py
@@ -162,8 +162,8 @@ if __name__ == "__main__":
     )[0]
     print(results)
 
-    os.makedirs(f'{args.persistent_dir}/results', exist_ok=True)
-    with open(f'{args.persistent_dir}/results/{experiment_id}.json', "w") as f:
+    os.makedirs(f'{args.persistent_dir}/results/roar', exist_ok=True)
+    with open(f'{args.persistent_dir}/results/roar/{experiment_id}.json', "w") as f:
         json.dump({"seed": args.seed, "dataset": "snli", "strategy": args.roar_strategy,
                    "k": args.k, "recursive": args.recursive, "importance_measure": args.importance_measure,
                    **results}, f)

--- a/experiments/stanford_sentiment.py
+++ b/experiments/stanford_sentiment.py
@@ -161,8 +161,8 @@ if __name__ == "__main__":
     )[0]
     print(results)
 
-    os.makedirs(f'{args.persistent_dir}/results', exist_ok=True)
-    with open(f'{args.persistent_dir}/results/{experiment_id}.json', "w") as f:
+    os.makedirs(f'{args.persistent_dir}/results/roar', exist_ok=True)
+    with open(f'{args.persistent_dir}/results/roar/{experiment_id}.json', "w") as f:
         json.dump({"seed": args.seed, "dataset": "sst", "strategy": args.roar_strategy,
                    "k": args.k, "recursive": args.recursive, "importance_measure": args.importance_measure,
                    **results}, f)

--- a/export/dataset_summary.py
+++ b/export/dataset_summary.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
 
     # Read JSON files into dataframe
     results = []
-    for file in glob.glob(f'{args.persistent_dir}/results/*.json'):
+    for file in glob.glob(f'{args.persistent_dir}/results/roar/*.json'):
         with open(file, 'r') as fp:
             try:
                 results.append(json.load(fp))

--- a/export/roar_plot.py
+++ b/export/roar_plot.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 
     # Read JSON files into dataframe
     results = []
-    for file in glob.glob(f'{args.persistent_dir}/results/*.json'):
+    for file in glob.glob(f'{args.persistent_dir}/results/roar/*.json'):
         with open(file, 'r') as fp:
             try:
                 results.append(json.load(fp))


### PR DESCRIPTION
To prevent/simplify the interactions with the `importance_measure` results.